### PR TITLE
Revert "arc: cleanup unused"

### DIFF
--- a/external/external.desc
+++ b/external/external.desc
@@ -1,0 +1,2 @@
+name: ARPL
+desc: ARPL external packages

--- a/external/external.mk
+++ b/external/external.mk
@@ -1,0 +1,1 @@
+include $(sort $(wildcard $(BR2_EXTERNAL_ARPL_PATH)/*/*.mk))


### PR DESCRIPTION
This reverts commit 6664d6d546c3ad9d67ededab8d5bd9d3d36fe1d1.