### PR TITLE
modulelist: add hwmon-vid.ko

### DIFF
--- a/files/initrd/opt/arc/include/modulelist
+++ b/files/initrd/opt/arc/include/modulelist
@@ -13,6 +13,7 @@ N kvm-amd.ko
 N kvm.ko
 
 # sensors
+N hwmon-vid.ko
 N coretemp.ko
 N k10temp.ko
 N it87.ko


### PR DESCRIPTION
The module is a dependency of the following modules present in the list:
- adt7475.ko
- nct6775.ko