### PR TITLE
fix: create p1 automated marker for grub automated boot

### DIFF
--- a/files/initrd/opt/arc/include/functions.sh
+++ b/files/initrd/opt/arc/include/functions.sh
@@ -348,6 +348,7 @@ function rebootTo() {
   [ -z "${1}" ] && exit 1
   if ! echo "${MODES}" | grep -wq "${1}"; then exit 1; fi
   [ "${1}" = "automated" ] && echo "arc-${MODEL}-${PRODUCTVER}-${ARC_VERSION}" >"${PART3_PATH}/automated"
+  [ "${1}" = "automated" ] && touch "${PART1_PATH}/automated"
   [ ! -f "${USER_GRUBENVFILE}" ] && grub-editenv "${USER_GRUBENVFILE}" create
   grub-editenv "${USER_GRUBENVFILE}" set next_entry="${1}"
   exec reboot


### PR DESCRIPTION
## Summary

`rebootTo automated` wrote only `PART3_PATH/automated`, but grub registers the `automated` menuentry only when `[ -e /automated ]` on the **p1 boot partition** at boot time. Without a p1 marker, `grub-editenv next_entry=automated` is ignored and the loader falls back to Config Mode (`force_arc`).

Adds `touch "${PART1_PATH}/automated"` when rebooting to automated mode.

## Reproduction

1. Seed `user-config.yml` with model/PAT keys.
2. Set `grub-editenv next_entry=automated` and write p3 marker only (current `rebootTo` behaviour).
3. Reboot → cmdline shows `force_arc`, not `automated_arc`.

With p1 marker → `automated_arc` boots and headless build completes.

Validated externally on Arc 3.1.0 / Proxmox (DS923+, DSM 7.2.2-72806).

## Test plan

- [ ] `rebootTo automated` creates both p3 marker file and p1 `/automated`
- [ ] Next boot enters `automated_arc` without manual `touch /mnt/p1/automated`
- [ ] Config Mode / other `rebootTo` targets unchanged