### PR TITLE
fix: loader disk detection fallback for SSH sessions

### DIFF
--- a/files/initrd/opt/arc/include/functions.sh
+++ b/files/initrd/opt/arc/include/functions.sh
@@ -332,6 +332,18 @@ function checkBIOS_VT_d() {
 }
 
 ###############################################################################
+# Resolve loader disk (mountloader addon or p1 mount fallback for SSH sessions)
+function loaderDiskDetect() {
+  [ -f "/usr/arc/.mountloader" ] && . "/usr/arc/.mountloader"
+  if [ -z "${LOADER_DISK}" ] && findmnt -no TARGET "${PART1_PATH}" &>/dev/null; then
+    local _part
+    _part="$(findmnt -no SOURCE --target "${PART1_PATH}")"
+    LOADER_DISK="$(lsblk -no PKNAME "${_part}" 2>/dev/null | head -1)"
+    [ -z "${LOADER_DISK}" ] && LOADER_DISK="$(echo "${_part}" | sed -E 's/p?[0-9]+$//')"
+  fi
+}
+
+###############################################################################
 # Rebooting
 function rebootTo() {
   BUILDDONE="$(readConfigKey "arc.builddone" "${USER_CONFIG_FILE}")"
@@ -480,7 +492,7 @@ function onlineCheck() {
 # Check System
 function systemCheck () {
   # Get Loader Disk Bus
-  [ -f "/usr/arc/.mountloader" ] && . "/usr/arc/.mountloader"
+  loaderDiskDetect
   BUS=$(getBus "${LOADER_DISK}")
   [ -z "${LOADER_DISK}" ] && die "Loader Disk not found!"
   # Check for Hypervisor

--- a/files/initrd/opt/arc/init.sh
+++ b/files/initrd/opt/arc/init.sh
@@ -23,6 +23,7 @@ if type vmware-toolbox-cmd >/dev/null 2>&1; then
 fi
 
 # Get Loader Disk Bus
+loaderDiskDetect
 [ -z "${LOADER_DISK}" ] && die "Loader Disk not found!"
 checkBootLoader || die "The loader is corrupted, please rewrite it!"
 arc_mode || die "No bootmode found!"


### PR DESCRIPTION
## Summary

Adds `loaderDiskDetect()` to resolve `LOADER_DISK` from the `/mnt/p1` mount when `/usr/arc/.mountloader` is not yet present (common on ad-hoc SSH before boot completes).

Used by `systemCheck()` and `init.sh`.

## Test plan

- [ ] SSH to loader without mountloader → `loaderDiskDetect` sets `LOADER_DISK=/dev/sda` (or equivalent)
- [ ] `systemCheck` no longer dies immediately over SSH